### PR TITLE
`Gleam` Tabs

### DIFF
--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -1,0 +1,46 @@
+use fltk::{prelude::*, *, group::*};
+use fltk_theme::{SchemeType, WidgetScheme};
+
+fn main() {
+    let a = app::App::default();
+    
+    let scheme = WidgetScheme::new(SchemeType::Gleam);
+    scheme.apply();
+    
+    let mut win = window::Window::default().with_size(400, 300);
+    win.make_resizable(true);
+    
+
+    let mut tabs = Tabs::default_fill();
+    
+    let t1 = Flex::default().with_label("Hello this is a very long string");
+    let mut choice = menu::Choice::new(100, 100, 200, 30, None);
+    choice.add_choice("Clean|Crystal|Gleam");
+    choice.set_value(2);
+    t1.end();
+
+    let t2 = Flex::default().with_label("Another long string!!!");
+    t2.end();
+
+    let t3 = Flex::default().with_label("Third tab to show you what's wrong");
+    t3.end();
+    
+    tabs.end();
+    tabs.auto_layout();
+    tabs.show();
+    
+    win.end();
+    win.show();
+
+    choice.set_callback(|c| {
+        let scheme = match c.value() {
+            0 => WidgetScheme::new(SchemeType::Clean),
+            1 => WidgetScheme::new(SchemeType::Crystal),
+            2 => WidgetScheme::new(SchemeType::Gleam),
+            _ => unimplemented!(),
+        };
+        scheme.apply();
+    });
+
+    a.run().unwrap();
+}

--- a/src/widget_schemes/gleam.rs
+++ b/src/widget_schemes/gleam.rs
@@ -10,29 +10,8 @@ fn frame_rect(x: i32, y: i32, w: i32, h: i32, bc: Color) {
 }
 
 fn shade_rect_up(x: i32, y: i32, w: i32, h: i32, bc: Color) {
-    // Draws the shiny
-    let third = h as f32 / 3.;
     set_draw_color(activated_color(bc));
-    draw_rectf(x, y, w, third as i32 + 1);
-
-    let step_size = 0.10 / (h as f32 - third);
-    let mut j = 0;
-
-    let mut k = 1.0;
-    loop {
-        if k >= 0.90 {
-            break;
-        }
-        j += 1;
-        set_draw_color(activated_color(Color::color_average(bc, Color::White, k)));
-        draw_line(
-            x,
-            y + j + third as i32 - 1,
-            x + w - 1,
-            y + j + third as i32 - 1,
-        );
-        k -= step_size;
-    }
+    draw_rectf(x, y, w, h);
 }
 
 fn frame_rect_up(x: i32, y: i32, w: i32, h: i32, bc: Color) {
@@ -86,7 +65,7 @@ fn up_frame(x: i32, y: i32, w: i32, h: i32, c: Color) {
 }
 
 fn up_box(x: i32, y: i32, w: i32, h: i32, c: Color) {
-    shade_rect_up(x + 1, y, w - 2, h - 1, c);
+    shade_rect_up(x + 1, y, w, h - 1, c);
     frame_rect_up(x, y, w - 1, h - 1, c.darker());
     //draw the inner rect.
     frame_rect(


### PR DESCRIPTION
Original `Gleam` widget scheme didn't work properly with `Tabs`.

There were different unwanted behaviors with different `TabsOverflow` handlers:
- `Compress`: text from compressed tabs was rendering over other tabs. Also half of the frame border was rendering over other tabs.
- `Pulldown`: text from any tab was rendering over pulldown button.

The fix was to change `shade_rect_up()` function from instantly breaking loop:
```rust
...
let mut k = 1.0;
    loop {
        if k >= 0.90 {
            break;
        }
...
```

to just filling the rectangle (I believe it's meant to draw some kind of gradient, but I didn't understand it, sorry):
```rust
fn shade_rect_up(x: i32, y: i32, w: i32, h: i32, bc: Color) {
    set_draw_color(activated_color(bc));
    draw_rectf(x, y, w, h);
}
```

The tabs example is added, showing this problem was present and is now fixed.
