### PR TITLE
widget_themes/mod.rs - fix typo

### DIFF
--- a/src/widget_themes/mod.rs
+++ b/src/widget_themes/mod.rs
@@ -53,7 +53,7 @@ pub(crate) const OS_BG_DOWN_BOX: FrameType =
 pub(crate) const OS_TOOLBAR_FRAME: FrameType =
     FrameType::UserFrameType(unsafe { UnmappedFrameType::from_i32(58) });
 
-pub const OS_FONT_SIZE: i32 = if cfg!(target_os = "window") { 12 } else { 13 };
+pub const OS_FONT_SIZE: i32 = if cfg!(target_os = "windows") { 12 } else { 13 };
 
 pub(crate) fn use_native_settings() {
     app::set_visible_focus(false);


### PR DESCRIPTION
From build log:

warning: unexpected `cfg` condition value: `window`
  --> fltk-theme/src/widget_themes/mod.rs:56:39
help: there is a expected value with a similar name: `"windows"`